### PR TITLE
Update Application_iOS_Add.ps1

### DIFF
--- a/Applications/Application_iOS_Add.ps1
+++ b/Applications/Application_iOS_Add.ps1
@@ -355,6 +355,17 @@ Function Add-iOSApplication(){
     }
 
 ####################################################
+# Set parameter for culture for script execution
+$culture = "EN-US"
+
+# Backup current culture
+$OldCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
+$OldUICulture = [System.Threading.Thread]::CurrentThread.CurrentUICulture
+
+
+# Set new Culture for script execution 
+[System.Threading.Thread]::CurrentThread.CurrentCulture = $culture
+[System.Threading.Thread]::CurrentThread.CurrentUICulture = $culture
 
 #region Authentication
 
@@ -485,3 +496,7 @@ else {
     }
 
 }
+
+# Restore culture from backup
+[System.Threading.Thread]::CurrentThread.CurrentCulture = $OldCulture
+[System.Threading.Thread]::CurrentThread.CurrentUICulture = $OldUICulture


### PR DESCRIPTION
If this script is run with SV-SE culture it will not work.
This change sets changes culture to EN-US during execution and restores this settings at script completion.
Script runs now without error.