### PR TITLE
Locig in script wrong

### DIFF
--- a/CheckStatus/Check_lastSyncDateTime.ps1
+++ b/CheckStatus/Check_lastSyncDateTime.ps1
@@ -292,7 +292,7 @@ Write-Host
 
     try {
 
-    $uri = "https://graph.microsoft.com/beta/deviceManagement/managedDevices?`$filter=lastSyncDateTime ge $daysago"
+    $uri = "https://graph.microsoft.com/beta/deviceManagement/managedDevices?`$filter=lastSyncDateTime le $daysago"
 
     $Devices = (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value | sort deviceName
 


### PR DESCRIPTION
When I runned the script it returned all devices synced the last 30 days and not all devices that had NOT synced. 
Corrected line 295 to use le instead of ge to correct this.