### PR TITLE
Fix NDES Service account NetBios validation

### DIFF
--- a/CertificationAuthority/Validate-NDESConfiguration.ps1
+++ b/CertificationAuthority/Validate-NDESConfiguration.ps1
@@ -41,7 +41,9 @@ Param(
     }
 
     $EnteredDomain = $_.split("\")
-    $Domain = (Get-WmiObject Win32_ComputerSystem).domain.split(".")[0]
+    $ads = New-Object -ComObject ADSystemInfo
+    $Domain = $ads.GetType().InvokeMember('DomainShortName','GetProperty', $Null, $ads, $Null)
+    
         if ($EnteredDomain -like "$Domain") {
 
         $True
@@ -61,7 +63,7 @@ Param(
 [parameter(Mandatory=$true,ParameterSetName="NormalRun")]
 [alias("ca")]
 [ValidateScript({
-    $Domain = $env:userdomain
+    $Domain = (Get-WmiObject Win32_ComputerSystem).domain
         if ($_ -match $Domain) {
 
         $True

--- a/CertificationAuthority/Validate-NDESConfiguration.ps1
+++ b/CertificationAuthority/Validate-NDESConfiguration.ps1
@@ -61,7 +61,7 @@ Param(
 [parameter(Mandatory=$true,ParameterSetName="NormalRun")]
 [alias("ca")]
 [ValidateScript({
-    $Domain = (Get-WmiObject Win32_ComputerSystem).domain
+    $Domain = (Get-ADDomain).NetBIOSName
         if ($_ -match $Domain) {
 
         $True

--- a/CertificationAuthority/Validate-NDESConfiguration.ps1
+++ b/CertificationAuthority/Validate-NDESConfiguration.ps1
@@ -61,7 +61,7 @@ Param(
 [parameter(Mandatory=$true,ParameterSetName="NormalRun")]
 [alias("ca")]
 [ValidateScript({
-    $Domain = (Get-ADDomain).NetBIOSName
+    $Domain = $env:userdomain
         if ($_ -match $Domain) {
 
         $True


### PR DESCRIPTION
New NDES account validation is not retrieving the correct NetBios name which will fail on domains with diferent NetBios from Domain name.