### PR TITLE
adding "PowerShell" switch to GetWin32AppBody function

### DIFF
--- a/LOB_Application/Win32_Application_Add.ps1
+++ b/LOB_Application/Win32_Application_Add.ps1
@@ -412,6 +412,9 @@ function GetWin32AppBody() {
         [parameter(Mandatory = $true, ParameterSetName = "EXE", Position = 1)]
         [Switch]$EXE,
 
+        [Parameter(Mandatory = $false, ParameterSetName = "PWSH", Position = 1)]
+        [switch]$PowerShell,
+
         [parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$displayName,
@@ -428,106 +431,121 @@ function GetWin32AppBody() {
         [ValidateNotNullOrEmpty()]
         [string]$filename,
 
-        [parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [string]$SetupFileName,
-
         [parameter(Mandatory = $false)]
         [ValidateSet('system', 'user')]
         $installExperience = "system",
 
+        [parameter(Mandatory = $true, ParameterSetName = "PWSH")]
+        [parameter(Mandatory = $true, ParameterSetName = "MSI")]
+        [ValidateNotNullOrEmpty()]
+        $setupFileName,
+
+        [parameter(Mandatory = $true, ParameterSetName = "PWSH")]
+        [parameter(Mandatory = $true, ParameterSetName = "EXE")]
+        [ValidateNotNullOrEmpty()]
+        $uninstallCommandLine,
+        
         [parameter(Mandatory = $true, ParameterSetName = "EXE")]
         [ValidateNotNullOrEmpty()]
         $installCommandLine,
 
-        [parameter(Mandatory = $true, ParameterSetName = "EXE")]
+        [parameter(Mandatory = $true, ParameterSetName = "MSI")]
         [ValidateNotNullOrEmpty()]
-        $uninstallCommandLine,
+        $msiPackageType,
 
         [parameter(Mandatory = $true, ParameterSetName = "MSI")]
         [ValidateNotNullOrEmpty()]
-        $MsiPackageType,
-
-        [parameter(Mandatory = $true, ParameterSetName = "MSI")]
-        [ValidateNotNullOrEmpty()]
-        $MsiProductCode,
+        $msiProductCode,
 
         [parameter(Mandatory = $false, ParameterSetName = "MSI")]
-        $MsiProductName,
+        $msiProductName,
 
         [parameter(Mandatory = $true, ParameterSetName = "MSI")]
         [ValidateNotNullOrEmpty()]
-        $MsiProductVersion,
+        $msiProductVersion,
 
         [parameter(Mandatory = $false, ParameterSetName = "MSI")]
-        $MsiPublisher,
+        $msiPublisher,
 
         [parameter(Mandatory = $true, ParameterSetName = "MSI")]
         [ValidateNotNullOrEmpty()]
-        $MsiRequiresReboot,
+        $msiRequiresReboot,
 
         [parameter(Mandatory = $true, ParameterSetName = "MSI")]
         [ValidateNotNullOrEmpty()]
-        $MsiUpgradeCode
+        $msiUpgradeCode
 
     )
 
-    if ($MSI) {
-
-        $body = @{ "@odata.type" = "#microsoft.graph.win32LobApp" };
-        $body.applicableArchitectures = "x64,x86";
-        $body.description = $description;
-        $body.developer = "";
-        $body.displayName = $displayName;
-        $body.fileName = $filename;
+    $body = @{ "@odata.type" = "#microsoft.graph.win32LobApp" }
+    if ($msi) {
+        $body.applicableArchitectures = "x64,x86"
+        $body.description = $description
+        $body.developer = ""
+        $body.displayName = $displayName
+        $body.fileName = $filename
         $body.installCommandLine = "msiexec /i `"$SetupFileName`""
-        $body.installExperience = @{"runAsAccount" = "$installExperience" };
-        $body.informationUrl = $null;
-        $body.isFeatured = $false;
-        $body.minimumSupportedOperatingSystem = @{"v10_1607" = $true };
+        $body.installExperience = @{"runAsAccount" = "$installExperience" }
+        $body.informationUrl = $null
+        $body.isFeatured = $false
+        $body.minimumSupportedOperatingSystem = @{"v10_1607" = $true }
         $body.msiInformation = @{
-            "packageType"    = "$MsiPackageType";
-            "productCode"    = "$MsiProductCode";
-            "productName"    = "$MsiProductName";
-            "productVersion" = "$MsiProductVersion";
-            "publisher"      = "$MsiPublisher";
-            "requiresReboot" = "$MsiRequiresReboot";
-            "upgradeCode"    = "$MsiUpgradeCode"
-        };
-        $body.notes = "";
-        $body.owner = "";
-        $body.privacyInformationUrl = $null;
-        $body.publisher = $publisher;
-        $body.runAs32bit = $false;
-        $body.setupFilePath = $SetupFileName;
-        $body.uninstallCommandLine = "msiexec /x `"$MsiProductCode`""
-
+            "packageType"    = "$msiPackageType"
+            "productCode"    = "$msiProductCode"
+            "productName"    = "$msiProductName"
+            "productVersion" = "$msiProductVersion"
+            "publisher"      = "$msiPublisher"
+            "requiresReboot" = "$msiRequiresReboot"
+            "upgradeCode"    = "$msiUpgradeCode"
+        }
+        $body.notes = ""
+        $body.owner = ""
+        $body.privacyInformationUrl = $null
+        $body.publisher = $publisher
+        $body.runAs32bit = $false
+        $body.setupFilePath = $SetupFileName
+        $body.uninstallCommandLine = "msiexec /x `"$msiProductCode`""
     }
-
     elseif ($EXE) {
-
-        $body = @{ "@odata.type" = "#microsoft.graph.win32LobApp" };
-        $body.description = $description;
-        $body.developer = "";
-        $body.displayName = $displayName;
-        $body.fileName = $filename;
+        $body.description = $description
+        $body.developer = ""
+        $body.displayName = $displayName
+        $body.fileName = $filename
         $body.installCommandLine = "$installCommandLine"
-        $body.installExperience = @{"runAsAccount" = "$installExperience" };
-        $body.informationUrl = $null;
-        $body.isFeatured = $false;
-        $body.minimumSupportedOperatingSystem = @{"v10_1607" = $true };
-        $body.msiInformation = $null;
-        $body.notes = "";
-        $body.owner = "";
-        $body.privacyInformationUrl = $null;
-        $body.publisher = $publisher;
-        $body.runAs32bit = $false;
-        $body.setupFilePath = $SetupFileName;
+        $body.installExperience = @{"runAsAccount" = "$installExperience" }
+        $body.informationUrl = $null
+        $body.isFeatured = $false
+        $body.minimumSupportedOperatingSystem = @{"v10_1607" = $true }
+        $body.msiInformation = $null
+        $body.notes = ""
+        $body.owner = ""
+        $body.privacyInformationUrl = $null
+        $body.publisher = $publisher
+        $body.runAs32bit = $false
+        $body.setupFilePath = $SetupFileName
         $body.uninstallCommandLine = "$uninstallCommandLine"
-
+    }
+    elseif ($PowerShell) {
+        $body.description = $description
+        $body.developer = ""
+        $body.displayName = $displayName
+        $body.fileName = $filename
+        $body.installCommandLine = "Powershell.exe -executionPolicy bypass -file './$SetupFileName'"
+        $body.installExperience = @{"runAsAccount" = "$installExperience" }
+        $body.informationUrl = $null
+        $body.isFeatured = $false
+        $body.minimumSupportedOperatingSystem = @{"v10_1607" = $true }
+        $body.msiInformation = $null
+        $body.notes = ""
+        $body.owner = ""
+        $body.privacyInformationUrl = $null
+        $body.publisher = $publisher
+        $body.runAs32bit = $false
+        $body.setupFilePath = $SetupFileName
+        $body.uninstallCommandLine = "$uninstallCommandLine"
     }
 
-    $body;
+    return $body
 }
 
 ####################################################
@@ -600,7 +618,7 @@ Function New-DetectionRule() {
         [Switch]$PowerShell,
 
         [parameter(Mandatory = $true, ParameterSetName = "MSI", Position = 1)]
-        [Switch]$MSI,
+        [Switch]$msi,
 
         [parameter(Mandatory = $true, ParameterSetName = "File", Position = 1)]
         [Switch]$File,
@@ -622,7 +640,7 @@ Function New-DetectionRule() {
 
         [parameter(Mandatory = $true, ParameterSetName = "MSI")]
         [ValidateNotNullOrEmpty()]
-        [String]$MSIproductCode,
+        [String]$msiProductCode,
    
         [parameter(Mandatory = $true, ParameterSetName = "File")]
         [ValidateNotNullOrEmpty()]
@@ -682,11 +700,11 @@ Function New-DetectionRule() {
 
     }
     
-    elseif ($MSI) {
+    elseif ($msi) {
     
         $DR = @{ "@odata.type" = "#microsoft.graph.win32LobAppProductCodeDetection" }
         $DR.productVersionOperator = "notConfigured";
-        $DR.productCode = "$MsiProductCode";
+        $DR.productCode = "$msiProductCode";
         $DR.productVersion = $null;
 
     }
@@ -914,19 +932,19 @@ NAME: Upload-Win32LOB
         if ((($Ext).contains("msi") -or ($Ext).contains("Msi")) -and (!$installCmdLine -or !$uninstallCmdLine)) {
 
             # MSI
-            $MsiExecutionContext = $DetectionXML.ApplicationInfo.MsiInfo.MsiExecutionContext
-            $MsiPackageType = "DualPurpose";
-            if ($MsiExecutionContext -eq "System") { $MsiPackageType = "PerMachine" }
-            elseif ($MsiExecutionContext -eq "User") { $MsiPackageType = "PerUser" }
+            $msiExecutionContext = $DetectionXML.ApplicationInfo.MsiInfo.MsiExecutionContext
+            $msiPackageType = "DualPurpose";
+            if ($msiExecutionContext -eq "System") { $msiPackageType = "PerMachine" }
+            elseif ($msiExecutionContext -eq "User") { $msiPackageType = "PerUser" }
 
-            $MsiProductCode = $DetectionXML.ApplicationInfo.MsiInfo.MsiProductCode
-            $MsiProductVersion = $DetectionXML.ApplicationInfo.MsiInfo.MsiProductVersion
-            $MsiPublisher = $DetectionXML.ApplicationInfo.MsiInfo.MsiPublisher
-            $MsiRequiresReboot = $DetectionXML.ApplicationInfo.MsiInfo.MsiRequiresReboot
-            $MsiUpgradeCode = $DetectionXML.ApplicationInfo.MsiInfo.MsiUpgradeCode
+            $msiProductCode = $DetectionXML.ApplicationInfo.MsiInfo.MsiProductCode
+            $msiProductVersion = $DetectionXML.ApplicationInfo.MsiInfo.MsiProductVersion
+            $msiPublisher = $DetectionXML.ApplicationInfo.MsiInfo.MsiPublisher
+            $msiRequiresReboot = $DetectionXML.ApplicationInfo.MsiInfo.MsiRequiresReboot
+            $msiUpgradeCode = $DetectionXML.ApplicationInfo.MsiInfo.MsiUpgradeCode
             
-            if ($MsiRequiresReboot -eq "false") { $MsiRequiresReboot = $false }
-            elseif ($MsiRequiresReboot -eq "true") { $MsiRequiresReboot = $true }
+            if ($msiRequiresReboot -eq "false") { $msiRequiresReboot = $false }
+            elseif ($msiRequiresReboot -eq "true") { $msiRequiresReboot = $true }
 
             $mobileAppBody = GetWin32AppBody `
                 -MSI `
@@ -936,13 +954,13 @@ NAME: Upload-Win32LOB
                 -filename $FileName `
                 -SetupFileName "$SetupFileName" `
                 -installExperience $installExperience `
-                -MsiPackageType $MsiPackageType `
-                -MsiProductCode $MsiProductCode `
+                -MsiPackageType $msiPackageType `
+                -MsiProductCode $msiProductCode `
                 -MsiProductName $displayName `
-                -MsiProductVersion $MsiProductVersion `
-                -MsiPublisher $MsiPublisher `
-                -MsiRequiresReboot $MsiRequiresReboot `
-                -MsiUpgradeCode $MsiUpgradeCode
+                -MsiProductVersion $msiProductVersion `
+                -MsiPublisher $msiPublisher `
+                -MsiRequiresReboot $msiRequiresReboot `
+                -MsiUpgradeCode $msiUpgradeCode
 
         }
 
@@ -1161,10 +1179,10 @@ $FileRule = New-DetectionRule -File -Path "C:\Program Files\Application" `
 $RegistryRule = New-DetectionRule -Registry -RegistryKeyPath "HKEY_LOCAL_MACHINE\SOFTWARE\Program" `
     -RegistryDetectionType exists -check32BitRegOn64System True
 
-$MSIRule = New-DetectionRule -MSI -MSIproductCode $DetectionXML.ApplicationInfo.MsiInfo.MsiProductCode
+$msiRule = New-DetectionRule -MSI -MSIproductCode $DetectionXML.ApplicationInfo.MsiInfo.MsiProductCode
 
 # Creating Array for detection Rule
-$DetectionRule = @($FileRule, $RegistryRule, $MSIRule)
+$DetectionRule = @($FileRule, $RegistryRule, $msiRule)
 
 $ReturnCodes = Get-DefaultReturnCodes
 

--- a/LOB_Application/Win32_Application_Add.ps1
+++ b/LOB_Application/Win32_Application_Add.ps1
@@ -779,8 +779,7 @@ Function Get-IntuneWinXML() {
         $fileName,
 
         [Parameter(Mandatory = $false)]
-        [ValidateSet("false", "true")]
-        [string]$removeitem = "true"
+        [switch]$removeitem
     )
 
     Test-SourceFile "$SourceFile"
@@ -791,9 +790,7 @@ Function Get-IntuneWinXML() {
     $zip = [IO.Compression.ZipFile]::OpenRead("$SourceFile")
 
     $zip.Entries | Where-Object { $_.Name -like "$filename" } | ForEach-Object {
-
         [System.IO.Compression.ZipFileExtensions]::ExtractToFile($_, "$Directory\$filename", $true)
-
     }
 
     $zip.Dispose()
@@ -802,7 +799,9 @@ Function Get-IntuneWinXML() {
 
     return $IntuneWinXML
 
-    if ($removeitem -eq "true") { remove-item "$Directory\$filename" }
+    if ($removeitem) { 
+        remove-item "$Directory\$filename" 
+    }
 
 }
 

--- a/LOB_Application/Win32_Application_Add.ps1
+++ b/LOB_Application/Win32_Application_Add.ps1
@@ -11,7 +11,7 @@ See LICENSE in the project root for license information.
 
 function Get-AuthToken {
 
-<#
+    <#
 .SYNOPSIS
 This function is used to authenticate with the Graph API REST interface
 .DESCRIPTION
@@ -23,19 +23,19 @@ Authenticates you with the Graph API interface
 NAME: Get-AuthToken
 #>
 
-[cmdletbinding()]
+    [cmdletbinding()]
 
-param
-(
-    [Parameter(Mandatory=$true)]
-    $User
-)
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        $User
+    )
 
-$userUpn = New-Object "System.Net.Mail.MailAddress" -ArgumentList $User
+    $userUpn = New-Object "System.Net.Mail.MailAddress" -ArgumentList $User
 
-$tenant = $userUpn.Host
+    $tenant = $userUpn.Host
 
-Write-Host "Checking for AzureAD module..."
+    Write-Host "Checking for AzureAD module..."
 
     $AadModule = Get-Module -Name "AzureAD" -ListAvailable
 
@@ -55,22 +55,22 @@ Write-Host "Checking for AzureAD module..."
         exit
     }
 
-# Getting path to ActiveDirectory Assemblies
-# If the module count is greater than 1 find the latest version
+    # Getting path to ActiveDirectory Assemblies
+    # If the module count is greater than 1 find the latest version
 
-    if($AadModule.count -gt 1){
+    if ($AadModule.count -gt 1) {
 
-        $Latest_Version = ($AadModule | select version | Sort-Object)[-1]
+        $Latest_Version = ($AadModule | Select-Object version | Sort-Object)[-1]
 
-        $aadModule = $AadModule | ? { $_.version -eq $Latest_Version.version }
+        $aadModule = $AadModule | Where-Object { $_.version -eq $Latest_Version.version }
 
-            # Checking if there are multiple versions of the same module found
+        # Checking if there are multiple versions of the same module found
 
-            if($AadModule.count -gt 1){
+        if ($AadModule.count -gt 1) {
 
-            $aadModule = $AadModule | select -Unique
+            $aadModule = $AadModule | Select-Object -Unique
 
-            }
+        }
 
         $adal = Join-Path $AadModule.ModuleBase "Microsoft.IdentityModel.Clients.ActiveDirectory.dll"
         $adalforms = Join-Path $AadModule.ModuleBase "Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll"
@@ -84,53 +84,53 @@ Write-Host "Checking for AzureAD module..."
 
     }
 
-[System.Reflection.Assembly]::LoadFrom($adal) | Out-Null
+    [System.Reflection.Assembly]::LoadFrom($adal) | Out-Null
 
-[System.Reflection.Assembly]::LoadFrom($adalforms) | Out-Null
+    [System.Reflection.Assembly]::LoadFrom($adalforms) | Out-Null
 
-$clientId = "d1ddf0e4-d672-4dae-b554-9d5bdfd93547"
+    $clientId = "d1ddf0e4-d672-4dae-b554-9d5bdfd93547"
 
-$redirectUri = "urn:ietf:wg:oauth:2.0:oob"
+    $redirectUri = "urn:ietf:wg:oauth:2.0:oob"
 
-$resourceAppIdURI = "https://graph.microsoft.com"
+    $resourceAppIdURI = "https://graph.microsoft.com"
 
-$authority = "https://login.microsoftonline.com/$Tenant"
+    $authority = "https://login.microsoftonline.com/$Tenant"
 
     try {
 
-    $authContext = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext" -ArgumentList $authority
+        $authContext = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext" -ArgumentList $authority
 
-    # https://msdn.microsoft.com/en-us/library/azure/microsoft.identitymodel.clients.activedirectory.promptbehavior.aspx
-    # Change the prompt behaviour to force credentials each time: Auto, Always, Never, RefreshSession
+        # https://msdn.microsoft.com/en-us/library/azure/microsoft.identitymodel.clients.activedirectory.promptbehavior.aspx
+        # Change the prompt behaviour to force credentials each time: Auto, Always, Never, RefreshSession
 
-    $platformParameters = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.PlatformParameters" -ArgumentList "Auto"
+        $platformParameters = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.PlatformParameters" -ArgumentList "Auto"
 
-    $userId = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.UserIdentifier" -ArgumentList ($User, "OptionalDisplayableId")
+        $userId = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.UserIdentifier" -ArgumentList ($User, "OptionalDisplayableId")
 
-    $authResult = $authContext.AcquireTokenAsync($resourceAppIdURI,$clientId,$redirectUri,$platformParameters,$userId).Result
+        $authResult = $authContext.AcquireTokenAsync($resourceAppIdURI, $clientId, $redirectUri, $platformParameters, $userId).Result
 
         # If the accesstoken is valid then create the authentication header
 
-        if($authResult.AccessToken){
+        if ($authResult.AccessToken) {
 
-        # Creating header for Authorization token
+            # Creating header for Authorization token
 
-        $authHeader = @{
-            'Content-Type'='application/json'
-            'Authorization'="Bearer " + $authResult.AccessToken
-            'ExpiresOn'=$authResult.ExpiresOn
+            $authHeader = @{
+                'Content-Type'  = 'application/json'
+                'Authorization' = "Bearer " + $authResult.AccessToken
+                'ExpiresOn'     = $authResult.ExpiresOn
             }
 
-        return $authHeader
+            return $authHeader
 
         }
 
         else {
 
-        Write-Host
-        Write-Host "Authorization Access Token is null, please re-run authentication..." -ForegroundColor Red
-        Write-Host
-        break
+            Write-Host
+            Write-Host "Authorization Access Token is null, please re-run authentication..." -ForegroundColor Red
+            Write-Host
+            break
 
         }
 
@@ -138,10 +138,10 @@ $authority = "https://login.microsoftonline.com/$Tenant"
 
     catch {
 
-    write-host $_.Exception.Message -f Red
-    write-host $_.Exception.ItemName -f Red
-    write-host
-    break
+        write-host $_.Exception.Message -f Red
+        write-host $_.Exception.ItemName -f Red
+        write-host
+        break
 
     }
 
@@ -149,455 +149,440 @@ $authority = "https://login.microsoftonline.com/$Tenant"
  
 ####################################################
 
-function CloneObject($object){
+function CloneObject($object) {
 
-	$stream = New-Object IO.MemoryStream;
-	$formatter = New-Object Runtime.Serialization.Formatters.Binary.BinaryFormatter;
-	$formatter.Serialize($stream, $object);
-	$stream.Position = 0;
-	$formatter.Deserialize($stream);
+    $stream = New-Object IO.MemoryStream
+    $formatter = New-Object Runtime.Serialization.Formatters.Binary.BinaryFormatter
+    $formatter.Serialize($stream, $object)
+    $stream.Position = 0
+    $formatter.Deserialize($stream)
 }
 
 ####################################################
 
-function WriteHeaders($authToken){
+function WriteHeaders($authToken) {
 
-	foreach ($header in $authToken.GetEnumerator())
-	{
-		if ($header.Name.ToLower() -eq "authorization")
-		{
-			continue;
-		}
+    foreach ($header in $authToken.GetEnumerator()) {
+        if ($header.Name.ToLower() -eq "authorization") {
+            continue;
+        }
 
-		Write-Host -ForegroundColor Gray "$($header.Name): $($header.Value)";
-	}
+        Write-Host -ForegroundColor Gray "$($header.Name): $($header.Value)";
+    }
 }
 
 ####################################################
 
-function MakeGetRequest($collectionPath){
+function MakeGetRequest($collectionPath) {
 
-	$uri = "$baseUrl$collectionPath";
-	$request = "GET $uri";
+    $uri = "$baseUrl$collectionPath";
+    $request = "GET $uri";
 	
-	if ($logRequestUris) { Write-Host $request; }
-	if ($logHeaders) { WriteHeaders $authToken; }
+    if ($logRequestUris) { Write-Host $request; }
+    if ($logHeaders) { WriteHeaders $authToken; }
 
-	try
-	{
-		Test-AuthToken
-		$response = Invoke-RestMethod $uri -Method Get -Headers $authToken;
-		$response;
-	}
-	catch
-	{
-		Write-Host -ForegroundColor Red $request;
-		Write-Host -ForegroundColor Red $_.Exception.Message;
-		throw;
-	}
+    try {
+        Test-AuthToken
+        $response = Invoke-RestMethod $uri -Method Get -Headers $authToken;
+        $response;
+    }
+    catch {
+        Write-Host -ForegroundColor Red $request;
+        Write-Host -ForegroundColor Red $_.Exception.Message;
+        throw;
+    }
 }
 
 ####################################################
 
-function MakePatchRequest($collectionPath, $body){
+function MakePatchRequest($collectionPath, $body) {
 
-	MakeRequest "PATCH" $collectionPath $body;
-
-}
-
-####################################################
-
-function MakePostRequest($collectionPath, $body){
-
-	MakeRequest "POST" $collectionPath $body;
+    MakeRequest "PATCH" $collectionPath $body;
 
 }
 
 ####################################################
 
-function MakeRequest($verb, $collectionPath, $body){
+function MakePostRequest($collectionPath, $body) {
 
-	$uri = "$baseUrl$collectionPath";
-	$request = "$verb $uri";
+    MakeRequest "POST" $collectionPath $body;
+
+}
+
+####################################################
+
+function MakeRequest($verb, $collectionPath, $body) {
+
+    $uri = "$baseUrl$collectionPath";
+    $request = "$verb $uri";
 	
-	$clonedHeaders = CloneObject $authToken;
-	$clonedHeaders["content-length"] = $body.Length;
-	$clonedHeaders["content-type"] = "application/json";
+    $clonedHeaders = CloneObject $authToken;
+    $clonedHeaders["content-length"] = $body.Length;
+    $clonedHeaders["content-type"] = "application/json";
 
-	if ($logRequestUris) { Write-Host $request; }
-	if ($logHeaders) { WriteHeaders $clonedHeaders; }
-	if ($logContent) { Write-Host -ForegroundColor Gray $body; }
+    if ($logRequestUris) { Write-Host $request; }
+    if ($logHeaders) { WriteHeaders $clonedHeaders; }
+    if ($logContent) { Write-Host -ForegroundColor Gray $body; }
 
-	try
-	{
-		Test-AuthToken
-		$response = Invoke-RestMethod $uri -Method $verb -Headers $clonedHeaders -Body $body;
-		$response;
-	}
-	catch
-	{
-		Write-Host -ForegroundColor Red $request;
-		Write-Host -ForegroundColor Red $_.Exception.Message;
-		throw;
-	}
+    try {
+        Test-AuthToken
+        $response = Invoke-RestMethod $uri -Method $verb -Headers $clonedHeaders -Body $body;
+        $response;
+    }
+    catch {
+        Write-Host -ForegroundColor Red $request;
+        Write-Host -ForegroundColor Red $_.Exception.Message;
+        throw;
+    }
 }
 
 ####################################################
 
-function UploadAzureStorageChunk($sasUri, $id, $body){
+function UploadAzureStorageChunk($sasUri, $id, $body) {
 
-	$uri = "$sasUri&comp=block&blockid=$id";
-	$request = "PUT $uri";
+    $uri = "$sasUri&comp=block&blockid=$id";
+    $request = "PUT $uri";
 
-	$iso = [System.Text.Encoding]::GetEncoding("iso-8859-1");
-	$encodedBody = $iso.GetString($body);
-	$headers = @{
-		"x-ms-blob-type" = "BlockBlob"
-	};
+    $iso = [System.Text.Encoding]::GetEncoding("iso-8859-1");
+    $encodedBody = $iso.GetString($body);
+    $headers = @{
+        "x-ms-blob-type" = "BlockBlob"
+    };
 
-	if ($logRequestUris) { Write-Host $request; }
-	if ($logHeaders) { WriteHeaders $headers; }
+    if ($logRequestUris) { Write-Host $request; }
+    if ($logHeaders) { WriteHeaders $headers; }
 
-	try
-	{
-		$response = Invoke-WebRequest $uri -Method Put -Headers $headers -Body $encodedBody;
-	}
-	catch
-	{
-		Write-Host -ForegroundColor Red $request;
-		Write-Host -ForegroundColor Red $_.Exception.Message;
-		throw;
-	}
+    try {
+        $response = Invoke-WebRequest $uri -Method Put -Headers $headers -Body $encodedBody;
+    }
+    catch {
+        Write-Host -ForegroundColor Red $request;
+        Write-Host -ForegroundColor Red $_.Exception.Message;
+        throw;
+    }
 
 }
 
 ####################################################
 
-function FinalizeAzureStorageUpload($sasUri, $ids){
+function FinalizeAzureStorageUpload($sasUri, $ids) {
 
-	$uri = "$sasUri&comp=blocklist";
-	$request = "PUT $uri";
+    $uri = "$sasUri&comp=blocklist";
+    $request = "PUT $uri";
 
-	$xml = '<?xml version="1.0" encoding="utf-8"?><BlockList>';
-	foreach ($id in $ids)
-	{
-		$xml += "<Latest>$id</Latest>";
-	}
-	$xml += '</BlockList>';
+    $xml = '<?xml version="1.0" encoding="utf-8"?><BlockList>';
+    foreach ($id in $ids) {
+        $xml += "<Latest>$id</Latest>";
+    }
+    $xml += '</BlockList>';
 
-	if ($logRequestUris) { Write-Host $request; }
-	if ($logContent) { Write-Host -ForegroundColor Gray $xml; }
+    if ($logRequestUris) { Write-Host $request; }
+    if ($logContent) { Write-Host -ForegroundColor Gray $xml; }
 
-	try
-	{
-		Invoke-RestMethod $uri -Method Put -Body $xml;
-	}
-	catch
-	{
-		Write-Host -ForegroundColor Red $request;
-		Write-Host -ForegroundColor Red $_.Exception.Message;
-		throw;
-	}
+    try {
+        Invoke-RestMethod $uri -Method Put -Body $xml;
+    }
+    catch {
+        Write-Host -ForegroundColor Red $request;
+        Write-Host -ForegroundColor Red $_.Exception.Message;
+        throw;
+    }
 }
 
 ####################################################
 
-function UploadFileToAzureStorage($sasUri, $filepath, $fileUri){
+function UploadFileToAzureStorage($sasUri, $filepath, $fileUri) {
 
-	try {
+    try {
 
         $chunkSizeInBytes = 1024l * 1024l * $azureStorageUploadChunkSizeInMb;
 		
-		# Start the timer for SAS URI renewal.
-		$sasRenewalTimer = [System.Diagnostics.Stopwatch]::StartNew()
+        # Start the timer for SAS URI renewal.
+        $sasRenewalTimer = [System.Diagnostics.Stopwatch]::StartNew()
 		
-		# Find the file size and open the file.
-		$fileSize = (Get-Item $filepath).length;
-		$chunks = [Math]::Ceiling($fileSize / $chunkSizeInBytes);
-		$reader = New-Object System.IO.BinaryReader([System.IO.File]::Open($filepath, [System.IO.FileMode]::Open));
-		$position = $reader.BaseStream.Seek(0, [System.IO.SeekOrigin]::Begin);
+        # Find the file size and open the file.
+        $fileSize = (Get-Item $filepath).length;
+        $chunks = [Math]::Ceiling($fileSize / $chunkSizeInBytes);
+        $reader = New-Object System.IO.BinaryReader([System.IO.File]::Open($filepath, [System.IO.FileMode]::Open));
+        $position = $reader.BaseStream.Seek(0, [System.IO.SeekOrigin]::Begin);
 		
-		# Upload each chunk. Check whether a SAS URI renewal is required after each chunk is uploaded and renew if needed.
-		$ids = @();
+        # Upload each chunk. Check whether a SAS URI renewal is required after each chunk is uploaded and renew if needed.
+        $ids = @();
 
-		for ($chunk = 0; $chunk -lt $chunks; $chunk++){
+        for ($chunk = 0; $chunk -lt $chunks; $chunk++) {
 
-			$id = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($chunk.ToString("0000")));
-			$ids += $id;
+            $id = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($chunk.ToString("0000")));
+            $ids += $id;
 
-			$start = $chunk * $chunkSizeInBytes;
-			$length = [Math]::Min($chunkSizeInBytes, $fileSize - $start);
-			$bytes = $reader.ReadBytes($length);
+            $start = $chunk * $chunkSizeInBytes;
+            $length = [Math]::Min($chunkSizeInBytes, $fileSize - $start);
+            $bytes = $reader.ReadBytes($length);
 			
-			$currentChunk = $chunk + 1;			
+            $currentChunk = $chunk + 1;			
 
             Write-Progress -Activity "Uploading File to Azure Storage" -status "Uploading chunk $currentChunk of $chunks" `
-            -percentComplete ($currentChunk / $chunks*100)
+                -percentComplete ($currentChunk / $chunks * 100)
 
             $uploadResponse = UploadAzureStorageChunk $sasUri $id $bytes;
 			
-			# Renew the SAS URI if 7 minutes have elapsed since the upload started or was renewed last.
-			if ($currentChunk -lt $chunks -and $sasRenewalTimer.ElapsedMilliseconds -ge 450000){
+            # Renew the SAS URI if 7 minutes have elapsed since the upload started or was renewed last.
+            if ($currentChunk -lt $chunks -and $sasRenewalTimer.ElapsedMilliseconds -ge 450000) {
 
-				$renewalResponse = RenewAzureStorageUpload $fileUri;
-				$sasRenewalTimer.Restart();
+                $renewalResponse = RenewAzureStorageUpload $fileUri;
+                $sasRenewalTimer.Restart();
 			
             }
 
-		}
+        }
 
         Write-Progress -Completed -Activity "Uploading File to Azure Storage"
 
-		$reader.Close();
+        $reader.Close();
 
-	}
+    }
 
-	finally {
+    finally {
 
-		if ($reader -ne $null) { $reader.Dispose(); }
+        if ($reader -ne $null) { $reader.Dispose(); }
 	
     }
 	
-	# Finalize the upload.
-	$uploadResponse = FinalizeAzureStorageUpload $sasUri $ids;
+    # Finalize the upload.
+    $uploadResponse = FinalizeAzureStorageUpload $sasUri $ids;
 
 }
 
 ####################################################
 
-function RenewAzureStorageUpload($fileUri){
+function RenewAzureStorageUpload($fileUri) {
 
-	$renewalUri = "$fileUri/renewUpload";
-	$actionBody = "";
-	$rewnewUriResult = MakePostRequest $renewalUri $actionBody;
+    $renewalUri = "$fileUri/renewUpload";
+    $actionBody = "";
+    $rewnewUriResult = MakePostRequest $renewalUri $actionBody;
 	
-	$file = WaitForFileProcessing $fileUri "AzureStorageUriRenewal" $azureStorageRenewSasUriBackOffTimeInSeconds;
+    $file = WaitForFileProcessing $fileUri "AzureStorageUriRenewal" $azureStorageRenewSasUriBackOffTimeInSeconds;
 
 }
 
 ####################################################
 
-function WaitForFileProcessing($fileUri, $stage){
+function WaitForFileProcessing($fileUri, $stage) {
 
-	$attempts= 600;
-	$waitTimeInSeconds = 10;
+    $attempts = 600;
+    $waitTimeInSeconds = 10;
 
-	$successState = "$($stage)Success";
-	$pendingState = "$($stage)Pending";
-	$failedState = "$($stage)Failed";
-	$timedOutState = "$($stage)TimedOut";
+    $successState = "$($stage)Success";
+    $pendingState = "$($stage)Pending";
+    $failedState = "$($stage)Failed";
+    $timedOutState = "$($stage)TimedOut";
 
-	$file = $null;
-	while ($attempts -gt 0)
-	{
-		$file = MakeGetRequest $fileUri;
+    $file = $null;
+    while ($attempts -gt 0) {
+        $file = MakeGetRequest $fileUri;
 
-		if ($file.uploadState -eq $successState)
-		{
-			break;
-		}
-		elseif ($file.uploadState -ne $pendingState)
-		{
-			Write-Host -ForegroundColor Red $_.Exception.Message;
+        if ($file.uploadState -eq $successState) {
+            break;
+        }
+        elseif ($file.uploadState -ne $pendingState) {
+            Write-Host -ForegroundColor Red $_.Exception.Message;
             throw "File upload state is not success: $($file.uploadState)";
-		}
+        }
 
-		Start-Sleep $waitTimeInSeconds;
-		$attempts--;
-	}
+        Start-Sleep $waitTimeInSeconds;
+        $attempts--;
+    }
 
-	if ($file -eq $null -or $file.uploadState -ne $successState)
-	{
-		throw "File request did not complete in the allotted time.";
-	}
+    if ($file -eq $null -or $file.uploadState -ne $successState) {
+        throw "File request did not complete in the allotted time.";
+    }
 
-	$file;
+    $file;
 }
 
 ####################################################
 
-function GetWin32AppBody(){
+function GetWin32AppBody() {
 
-param
-(
+    param
+    (
 
-[parameter(Mandatory=$true,ParameterSetName = "MSI",Position=1)]
-[Switch]$MSI,
+        [parameter(Mandatory = $true, ParameterSetName = "MSI", Position = 1)]
+        [Switch]$MSI,
 
-[parameter(Mandatory=$true,ParameterSetName = "EXE",Position=1)]
-[Switch]$EXE,
+        [parameter(Mandatory = $true, ParameterSetName = "EXE", Position = 1)]
+        [Switch]$EXE,
 
-[parameter(Mandatory=$true)]
-[ValidateNotNullOrEmpty()]
-[string]$displayName,
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$displayName,
 
-[parameter(Mandatory=$true)]
-[ValidateNotNullOrEmpty()]
-[string]$publisher,
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$publisher,
 
-[parameter(Mandatory=$true)]
-[ValidateNotNullOrEmpty()]
-[string]$description,
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$description,
 
-[parameter(Mandatory=$true)]
-[ValidateNotNullOrEmpty()]
-[string]$filename,
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$filename,
 
-[parameter(Mandatory=$true)]
-[ValidateNotNullOrEmpty()]
-[string]$SetupFileName,
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$SetupFileName,
 
-[parameter(Mandatory=$true)]
-[ValidateSet('system','user')]
-$installExperience = "system",
+        [parameter(Mandatory = $false)]
+        [ValidateSet('system', 'user')]
+        $installExperience = "system",
 
-[parameter(Mandatory=$true,ParameterSetName = "EXE")]
-[ValidateNotNullOrEmpty()]
-$installCommandLine,
+        [parameter(Mandatory = $true, ParameterSetName = "EXE")]
+        [ValidateNotNullOrEmpty()]
+        $installCommandLine,
 
-[parameter(Mandatory=$true,ParameterSetName = "EXE")]
-[ValidateNotNullOrEmpty()]
-$uninstallCommandLine,
+        [parameter(Mandatory = $true, ParameterSetName = "EXE")]
+        [ValidateNotNullOrEmpty()]
+        $uninstallCommandLine,
 
-[parameter(Mandatory=$true,ParameterSetName = "MSI")]
-[ValidateNotNullOrEmpty()]
-$MsiPackageType,
+        [parameter(Mandatory = $true, ParameterSetName = "MSI")]
+        [ValidateNotNullOrEmpty()]
+        $MsiPackageType,
 
-[parameter(Mandatory=$true,ParameterSetName = "MSI")]
-[ValidateNotNullOrEmpty()]
-$MsiProductCode,
+        [parameter(Mandatory = $true, ParameterSetName = "MSI")]
+        [ValidateNotNullOrEmpty()]
+        $MsiProductCode,
 
-[parameter(Mandatory=$false,ParameterSetName = "MSI")]
-$MsiProductName,
+        [parameter(Mandatory = $false, ParameterSetName = "MSI")]
+        $MsiProductName,
 
-[parameter(Mandatory=$true,ParameterSetName = "MSI")]
-[ValidateNotNullOrEmpty()]
-$MsiProductVersion,
+        [parameter(Mandatory = $true, ParameterSetName = "MSI")]
+        [ValidateNotNullOrEmpty()]
+        $MsiProductVersion,
 
-[parameter(Mandatory=$false,ParameterSetName = "MSI")]
-$MsiPublisher,
+        [parameter(Mandatory = $false, ParameterSetName = "MSI")]
+        $MsiPublisher,
 
-[parameter(Mandatory=$true,ParameterSetName = "MSI")]
-[ValidateNotNullOrEmpty()]
-$MsiRequiresReboot,
+        [parameter(Mandatory = $true, ParameterSetName = "MSI")]
+        [ValidateNotNullOrEmpty()]
+        $MsiRequiresReboot,
 
-[parameter(Mandatory=$true,ParameterSetName = "MSI")]
-[ValidateNotNullOrEmpty()]
-$MsiUpgradeCode
+        [parameter(Mandatory = $true, ParameterSetName = "MSI")]
+        [ValidateNotNullOrEmpty()]
+        $MsiUpgradeCode
 
-)
+    )
 
-    if($MSI){
+    if ($MSI) {
 
-	    $body = @{ "@odata.type" = "#microsoft.graph.win32LobApp" };
+        $body = @{ "@odata.type" = "#microsoft.graph.win32LobApp" };
         $body.applicableArchitectures = "x64,x86";
         $body.description = $description;
-	    $body.developer = "";
-	    $body.displayName = $displayName;
-	    $body.fileName = $filename;
+        $body.developer = "";
+        $body.displayName = $displayName;
+        $body.fileName = $filename;
         $body.installCommandLine = "msiexec /i `"$SetupFileName`""
-        $body.installExperience = @{"runAsAccount" = "$installExperience"};
-	    $body.informationUrl = $null;
-	    $body.isFeatured = $false;
-        $body.minimumSupportedOperatingSystem = @{"v10_1607" = $true};
+        $body.installExperience = @{"runAsAccount" = "$installExperience" };
+        $body.informationUrl = $null;
+        $body.isFeatured = $false;
+        $body.minimumSupportedOperatingSystem = @{"v10_1607" = $true };
         $body.msiInformation = @{
-            "packageType" = "$MsiPackageType";
-            "productCode" = "$MsiProductCode";
-            "productName" = "$MsiProductName";
+            "packageType"    = "$MsiPackageType";
+            "productCode"    = "$MsiProductCode";
+            "productName"    = "$MsiProductName";
             "productVersion" = "$MsiProductVersion";
-            "publisher" = "$MsiPublisher";
+            "publisher"      = "$MsiPublisher";
             "requiresReboot" = "$MsiRequiresReboot";
-            "upgradeCode" = "$MsiUpgradeCode"
+            "upgradeCode"    = "$MsiUpgradeCode"
         };
-	    $body.notes = "";
-	    $body.owner = "";
-	    $body.privacyInformationUrl = $null;
-	    $body.publisher = $publisher;
+        $body.notes = "";
+        $body.owner = "";
+        $body.privacyInformationUrl = $null;
+        $body.publisher = $publisher;
         $body.runAs32bit = $false;
         $body.setupFilePath = $SetupFileName;
         $body.uninstallCommandLine = "msiexec /x `"$MsiProductCode`""
 
     }
 
-    elseif($EXE){
+    elseif ($EXE) {
 
         $body = @{ "@odata.type" = "#microsoft.graph.win32LobApp" };
         $body.description = $description;
-	    $body.developer = "";
-	    $body.displayName = $displayName;
-	    $body.fileName = $filename;
+        $body.developer = "";
+        $body.displayName = $displayName;
+        $body.fileName = $filename;
         $body.installCommandLine = "$installCommandLine"
-        $body.installExperience = @{"runAsAccount" = "$installExperience"};
-	    $body.informationUrl = $null;
-	    $body.isFeatured = $false;
-        $body.minimumSupportedOperatingSystem = @{"v10_1607" = $true};
+        $body.installExperience = @{"runAsAccount" = "$installExperience" };
+        $body.informationUrl = $null;
+        $body.isFeatured = $false;
+        $body.minimumSupportedOperatingSystem = @{"v10_1607" = $true };
         $body.msiInformation = $null;
-	    $body.notes = "";
-	    $body.owner = "";
-	    $body.privacyInformationUrl = $null;
-	    $body.publisher = $publisher;
+        $body.notes = "";
+        $body.owner = "";
+        $body.privacyInformationUrl = $null;
+        $body.publisher = $publisher;
         $body.runAs32bit = $false;
         $body.setupFilePath = $SetupFileName;
         $body.uninstallCommandLine = "$uninstallCommandLine"
 
     }
 
-	$body;
+    $body;
 }
 
 ####################################################
 
-function GetAppFileBody($name, $size, $sizeEncrypted, $manifest){
+function GetAppFileBody($name, $size, $sizeEncrypted, $manifest) {
 
-	$body = @{ "@odata.type" = "#microsoft.graph.mobileAppContentFile" };
-	$body.name = $name;
-	$body.size = $size;
-	$body.sizeEncrypted = $sizeEncrypted;
-	$body.manifest = $manifest;
+    $body = @{ "@odata.type" = "#microsoft.graph.mobileAppContentFile" };
+    $body.name = $name;
+    $body.size = $size;
+    $body.sizeEncrypted = $sizeEncrypted;
+    $body.manifest = $manifest;
     $body.isDependency = $false;
 
-	$body;
+    $body;
 }
 
 ####################################################
 
-function GetAppCommitBody($contentVersionId, $LobType){
+function GetAppCommitBody($contentVersionId, $LobType) {
 
-	$body = @{ "@odata.type" = "#$LobType" };
-	$body.committedContentVersion = $contentVersionId;
+    $body = @{ "@odata.type" = "#$LobType" };
+    $body.committedContentVersion = $contentVersionId;
 
-	$body;
+    $body;
 
 }
 
 ####################################################
 
-Function Test-SourceFile(){
+Function Test-SourceFile() {
 
-param
-(
-    [parameter(Mandatory=$true)]
-    [ValidateNotNullOrEmpty()]
-    $SourceFile
-)
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        $SourceFile
+    )
 
     try {
 
-            if(!(test-path "$SourceFile")){
+        if (!(test-path "$SourceFile")) {
 
             Write-Host
             Write-Host "Source File '$sourceFile' doesn't exist..." -ForegroundColor Red
             throw
 
-            }
-
         }
+
+    }
 
     catch {
 
-		Write-Host -ForegroundColor Red $_.Exception.Message;
+        Write-Host -ForegroundColor Red $_.Exception.Message;
         Write-Host
-		break
+        break
 
     }
 
@@ -605,80 +590,80 @@ param
 
 ####################################################
 
-Function New-DetectionRule(){
+Function New-DetectionRule() {
 
-[cmdletbinding()]
+    [cmdletbinding()]
 
-param
-(
- [parameter(Mandatory=$true,ParameterSetName = "PowerShell",Position=1)]
- [Switch]$PowerShell,
+    param
+    (
+        [parameter(Mandatory = $true, ParameterSetName = "PowerShell", Position = 1)]
+        [Switch]$PowerShell,
 
- [parameter(Mandatory=$true,ParameterSetName = "MSI",Position=1)]
- [Switch]$MSI,
+        [parameter(Mandatory = $true, ParameterSetName = "MSI", Position = 1)]
+        [Switch]$MSI,
 
- [parameter(Mandatory=$true,ParameterSetName = "File",Position=1)]
- [Switch]$File,
+        [parameter(Mandatory = $true, ParameterSetName = "File", Position = 1)]
+        [Switch]$File,
 
- [parameter(Mandatory=$true,ParameterSetName = "Registry",Position=1)]
- [Switch]$Registry,
+        [parameter(Mandatory = $true, ParameterSetName = "Registry", Position = 1)]
+        [Switch]$Registry,
 
- [parameter(Mandatory=$true,ParameterSetName = "PowerShell")]
- [ValidateNotNullOrEmpty()]
- [String]$ScriptFile,
+        [parameter(Mandatory = $true, ParameterSetName = "PowerShell")]
+        [ValidateNotNullOrEmpty()]
+        [String]$ScriptFile,
 
- [parameter(Mandatory=$true,ParameterSetName = "PowerShell")]
- [ValidateNotNullOrEmpty()]
- $enforceSignatureCheck,
+        [parameter(Mandatory = $true, ParameterSetName = "PowerShell")]
+        [ValidateNotNullOrEmpty()]
+        $enforceSignatureCheck,
 
- [parameter(Mandatory=$true,ParameterSetName = "PowerShell")]
- [ValidateNotNullOrEmpty()]
- $runAs32Bit,
+        [parameter(Mandatory = $true, ParameterSetName = "PowerShell")]
+        [ValidateNotNullOrEmpty()]
+        $runAs32Bit,
 
- [parameter(Mandatory=$true,ParameterSetName = "MSI")]
- [ValidateNotNullOrEmpty()]
- [String]$MSIproductCode,
+        [parameter(Mandatory = $true, ParameterSetName = "MSI")]
+        [ValidateNotNullOrEmpty()]
+        [String]$MSIproductCode,
    
- [parameter(Mandatory=$true,ParameterSetName = "File")]
- [ValidateNotNullOrEmpty()]
- [String]$Path,
+        [parameter(Mandatory = $true, ParameterSetName = "File")]
+        [ValidateNotNullOrEmpty()]
+        [String]$Path,
  
- [parameter(Mandatory=$true,ParameterSetName = "File")]
- [ValidateNotNullOrEmpty()]
- [string]$FileOrFolderName,
+        [parameter(Mandatory = $true, ParameterSetName = "File")]
+        [ValidateNotNullOrEmpty()]
+        [string]$FileOrFolderName,
 
- [parameter(Mandatory=$true,ParameterSetName = "File")]
- [ValidateSet("notConfigured","exists","modifiedDate","createdDate","version","sizeInMB")]
- [string]$FileDetectionType,
+        [parameter(Mandatory = $true, ParameterSetName = "File")]
+        [ValidateSet("notConfigured", "exists", "modifiedDate", "createdDate", "version", "sizeInMB")]
+        [string]$FileDetectionType,
 
- [parameter(Mandatory=$false,ParameterSetName = "File")]
- $FileDetectionValue = $null,
+        [parameter(Mandatory = $false, ParameterSetName = "File")]
+        $FileDetectionValue = $null,
 
- [parameter(Mandatory=$true,ParameterSetName = "File")]
- [ValidateSet("True","False")]
- [string]$check32BitOn64System = "False",
+        [parameter(Mandatory = $true, ParameterSetName = "File")]
+        [ValidateSet("True", "False")]
+        [string]$check32BitOn64System = "False",
 
- [parameter(Mandatory=$true,ParameterSetName = "Registry")]
- [ValidateNotNullOrEmpty()]
- [String]$RegistryKeyPath,
+        [parameter(Mandatory = $true, ParameterSetName = "Registry")]
+        [ValidateNotNullOrEmpty()]
+        [String]$RegistryKeyPath,
 
- [parameter(Mandatory=$true,ParameterSetName = "Registry")]
- [ValidateSet("notConfigured","exists","doesNotExist","string","integer","version")]
- [string]$RegistryDetectionType,
+        [parameter(Mandatory = $true, ParameterSetName = "Registry")]
+        [ValidateSet("notConfigured", "exists", "doesNotExist", "string", "integer", "version")]
+        [string]$RegistryDetectionType,
 
- [parameter(Mandatory=$false,ParameterSetName = "Registry")]
- [ValidateNotNullOrEmpty()]
- [String]$RegistryValue,
+        [parameter(Mandatory = $false, ParameterSetName = "Registry")]
+        [ValidateNotNullOrEmpty()]
+        [String]$RegistryValue,
 
- [parameter(Mandatory=$true,ParameterSetName = "Registry")]
- [ValidateSet("True","False")]
- [string]$check32BitRegOn64System = "False"
+        [parameter(Mandatory = $true, ParameterSetName = "Registry")]
+        [ValidateSet("True", "False")]
+        [string]$check32BitRegOn64System = "False"
 
-)
+    )
 
-    if($PowerShell){
+    if ($PowerShell) {
 
-        if(!(Test-Path "$ScriptFile")){
+        if (!(Test-Path "$ScriptFile")) {
             
             Write-Host
             Write-Host "Could not find file '$ScriptFile'..." -ForegroundColor Red
@@ -693,32 +678,32 @@ param
         $DR = @{ "@odata.type" = "#microsoft.graph.win32LobAppPowerShellScriptDetection" }
         $DR.enforceSignatureCheck = $false;
         $DR.runAs32Bit = $false;
-        $DR.scriptContent =  "$ScriptContent";
+        $DR.scriptContent = "$ScriptContent";
 
     }
     
-    elseif($MSI){
+    elseif ($MSI) {
     
         $DR = @{ "@odata.type" = "#microsoft.graph.win32LobAppProductCodeDetection" }
         $DR.productVersionOperator = "notConfigured";
         $DR.productCode = "$MsiProductCode";
-        $DR.productVersion =  $null;
+        $DR.productVersion = $null;
 
     }
 
-    elseif($File){
+    elseif ($File) {
     
         $DR = @{ "@odata.type" = "#microsoft.graph.win32LobAppFileSystemDetection" }
         $DR.check32BitOn64System = "$check32BitOn64System";
         $DR.detectionType = "$FileDetectionType";
         $DR.detectionValue = $FileDetectionValue;
         $DR.fileOrFolderName = "$FileOrFolderName";
-        $DR.operator =  "notConfigured";
+        $DR.operator = "notConfigured";
         $DR.path = "$Path"
 
     }
 
-    elseif($Registry){
+    elseif ($Registry) {
     
         $DR = @{ "@odata.type" = "#microsoft.graph.win32LobAppRegistryDetection" }
         $DR.check32BitOn64System = "$check32BitRegOn64System";
@@ -736,92 +721,92 @@ param
 
 ####################################################
 
-function Get-DefaultReturnCodes(){
+function Get-DefaultReturnCodes() {
 
-@{"returnCode" = 0;"type" = "success"}, `
-@{"returnCode" = 1707;"type" = "success"}, `
-@{"returnCode" = 3010;"type" = "softReboot"}, `
-@{"returnCode" = 1641;"type" = "hardReboot"}, `
-@{"returnCode" = 1618;"type" = "retry"}
-
-}
-
-####################################################
-
-function New-ReturnCode(){
-
-param
-(
-[parameter(Mandatory=$true)]
-[int]$returnCode,
-[parameter(Mandatory=$true)]
-[ValidateSet('success','softReboot','hardReboot','retry')]
-$type
-)
-
-    @{"returnCode" = $returnCode;"type" = "$type"}
+    @{"returnCode" = 0; "type" = "success" }, `
+    @{"returnCode" = 1707; "type" = "success" }, `
+    @{"returnCode" = 3010; "type" = "softReboot" }, `
+    @{"returnCode" = 1641; "type" = "hardReboot" }, `
+    @{"returnCode" = 1618; "type" = "retry" }
 
 }
 
 ####################################################
 
-Function Get-IntuneWinXML(){
+function New-ReturnCode() {
 
-param
-(
-[Parameter(Mandatory=$true)]
-$SourceFile,
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [int]$returnCode,
+        [parameter(Mandatory = $true)]
+        [ValidateSet('success', 'softReboot', 'hardReboot', 'retry')]
+        $type
+    )
 
-[Parameter(Mandatory=$true)]
-$fileName,
-
-[Parameter(Mandatory=$false)]
-[ValidateSet("false","true")]
-[string]$removeitem = "true"
-)
-
-Test-SourceFile "$SourceFile"
-
-$Directory = [System.IO.Path]::GetDirectoryName("$SourceFile")
-
-Add-Type -Assembly System.IO.Compression.FileSystem
-$zip = [IO.Compression.ZipFile]::OpenRead("$SourceFile")
-
-    $zip.Entries | where {$_.Name -like "$filename" } | foreach {
-
-    [System.IO.Compression.ZipFileExtensions]::ExtractToFile($_, "$Directory\$filename", $true)
-
-    }
-
-$zip.Dispose()
-
-[xml]$IntuneWinXML = gc "$Directory\$filename"
-
-return $IntuneWinXML
-
-if($removeitem -eq "true"){ remove-item "$Directory\$filename" }
+    @{"returnCode" = $returnCode; "type" = "$type" }
 
 }
 
 ####################################################
 
-Function Get-IntuneWinFile(){
+Function Get-IntuneWinXML() {
 
-param
-(
-[Parameter(Mandatory=$true)]
-$SourceFile,
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        $SourceFile,
 
-[Parameter(Mandatory=$true)]
-$fileName,
+        [Parameter(Mandatory = $true)]
+        $fileName,
 
-[Parameter(Mandatory=$false)]
-[string]$Folder = "win32"
-)
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("false", "true")]
+        [string]$removeitem = "true"
+    )
+
+    Test-SourceFile "$SourceFile"
 
     $Directory = [System.IO.Path]::GetDirectoryName("$SourceFile")
 
-    if(!(Test-Path "$Directory\$folder")){
+    Add-Type -Assembly System.IO.Compression.FileSystem
+    $zip = [IO.Compression.ZipFile]::OpenRead("$SourceFile")
+
+    $zip.Entries | Where-Object { $_.Name -like "$filename" } | ForEach-Object {
+
+        [System.IO.Compression.ZipFileExtensions]::ExtractToFile($_, "$Directory\$filename", $true)
+
+    }
+
+    $zip.Dispose()
+
+    [xml]$IntuneWinXML = Get-Content "$Directory\$filename"
+
+    return $IntuneWinXML
+
+    if ($removeitem -eq "true") { remove-item "$Directory\$filename" }
+
+}
+
+####################################################
+
+Function Get-IntuneWinFile() {
+
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        $SourceFile,
+
+        [Parameter(Mandatory = $true)]
+        $fileName,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Folder = "win32"
+    )
+
+    $Directory = [System.IO.Path]::GetDirectoryName("$SourceFile")
+
+    if (!(Test-Path "$Directory\$folder")) {
 
         New-Item -ItemType Directory -Path "$Directory" -Name "$folder" | Out-Null
 
@@ -830,25 +815,25 @@ $fileName,
     Add-Type -Assembly System.IO.Compression.FileSystem
     $zip = [IO.Compression.ZipFile]::OpenRead("$SourceFile")
 
-        $zip.Entries | where {$_.Name -like "$filename" } | foreach {
+    $zip.Entries | Where-Object { $_.Name -like "$filename" } | ForEach-Object {
 
         [System.IO.Compression.ZipFileExtensions]::ExtractToFile($_, "$Directory\$folder\$filename", $true)
 
-        }
+    }
 
     $zip.Dispose()
 
     return "$Directory\$folder\$filename"
 
-    if($removeitem -eq "true"){ remove-item "$Directory\$filename" }
+    if ($removeitem -eq "true") { remove-item "$Directory\$filename" }
 
 }
 
 ####################################################
 
-function Upload-Win32Lob(){
+function Upload-Win32Lob() {
 
-<#
+    <#
 .SYNOPSIS
 This function is used to upload a Win32 Application to the Intune Service
 .DESCRIPTION
@@ -860,48 +845,48 @@ This example uses all parameters required to add an intunewin File into the Intu
 NAME: Upload-Win32LOB
 #>
 
-[cmdletbinding()]
+    [cmdletbinding()]
 
-param
-(
-    [parameter(Mandatory=$true,Position=1)]
-    [ValidateNotNullOrEmpty()]
-    [string]$SourceFile,
+    param
+    (
+        [parameter(Mandatory = $true, Position = 1)]
+        [ValidateNotNullOrEmpty()]
+        [string]$SourceFile,
 
-    [parameter(Mandatory=$false)]
-    [ValidateNotNullOrEmpty()]
-    [string]$displayName,
+        [parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [string]$displayName,
 
-    [parameter(Mandatory=$true,Position=2)]
-    [ValidateNotNullOrEmpty()]
-    [string]$publisher,
+        [parameter(Mandatory = $true, Position = 2)]
+        [ValidateNotNullOrEmpty()]
+        [string]$publisher,
 
-    [parameter(Mandatory=$true,Position=3)]
-    [ValidateNotNullOrEmpty()]
-    [string]$description,
+        [parameter(Mandatory = $true, Position = 3)]
+        [ValidateNotNullOrEmpty()]
+        [string]$description,
 
-    [parameter(Mandatory=$true,Position=4)]
-    [ValidateNotNullOrEmpty()]
-    $detectionRules,
+        [parameter(Mandatory = $true, Position = 4)]
+        [ValidateNotNullOrEmpty()]
+        $detectionRules,
 
-    [parameter(Mandatory=$true,Position=5)]
-    [ValidateNotNullOrEmpty()]
-    $returnCodes,
+        [parameter(Mandatory = $true, Position = 5)]
+        [ValidateNotNullOrEmpty()]
+        $returnCodes,
 
-    [parameter(Mandatory=$false,Position=6)]
-    [ValidateNotNullOrEmpty()]
-    [string]$installCmdLine,
+        [parameter(Mandatory = $false, Position = 6)]
+        [ValidateNotNullOrEmpty()]
+        [string]$installCmdLine,
 
-    [parameter(Mandatory=$false,Position=7)]
-    [ValidateNotNullOrEmpty()]
-    [string]$uninstallCmdLine,
+        [parameter(Mandatory = $false, Position = 7)]
+        [ValidateNotNullOrEmpty()]
+        [string]$uninstallCmdLine,
 
-    [parameter(Mandatory=$false,Position=8)]
-    [ValidateSet('system','user')]
-    $installExperience = "system"
-)
+        [parameter(Mandatory = $false, Position = 8)]
+        [ValidateSet('system', 'user')]
+        $installExperience = "system"
+    )
 
-	try	{
+    try	{
 
         $LOBType = "microsoft.graph.win32LobApp"
 
@@ -917,7 +902,7 @@ param
         $DetectionXML = Get-IntuneWinXML "$SourceFile" -fileName "detection.xml"
 
         # If displayName input don't use Name from detection.xml file
-        if($displayName){ $DisplayName = $displayName }
+        if ($displayName) { $DisplayName = $displayName }
         else { $DisplayName = $DetectionXML.ApplicationInfo.Name }
         
         $FileName = $DetectionXML.ApplicationInfo.FileName
@@ -926,13 +911,13 @@ param
 
         $Ext = [System.IO.Path]::GetExtension($SetupFileName)
 
-        if((($Ext).contains("msi") -or ($Ext).contains("Msi")) -and (!$installCmdLine -or !$uninstallCmdLine)){
+        if ((($Ext).contains("msi") -or ($Ext).contains("Msi")) -and (!$installCmdLine -or !$uninstallCmdLine)) {
 
-		    # MSI
+            # MSI
             $MsiExecutionContext = $DetectionXML.ApplicationInfo.MsiInfo.MsiExecutionContext
             $MsiPackageType = "DualPurpose";
-            if($MsiExecutionContext -eq "System") { $MsiPackageType = "PerMachine" }
-            elseif($MsiExecutionContext -eq "User") { $MsiPackageType = "PerUser" }
+            if ($MsiExecutionContext -eq "System") { $MsiPackageType = "PerMachine" }
+            elseif ($MsiExecutionContext -eq "User") { $MsiPackageType = "PerUser" }
 
             $MsiProductCode = $DetectionXML.ApplicationInfo.MsiInfo.MsiProductCode
             $MsiProductVersion = $DetectionXML.ApplicationInfo.MsiInfo.MsiProductVersion
@@ -940,8 +925,8 @@ param
             $MsiRequiresReboot = $DetectionXML.ApplicationInfo.MsiInfo.MsiRequiresReboot
             $MsiUpgradeCode = $DetectionXML.ApplicationInfo.MsiInfo.MsiUpgradeCode
             
-            if($MsiRequiresReboot -eq "false"){ $MsiRequiresReboot = $false }
-            elseif($MsiRequiresReboot -eq "true"){ $MsiRequiresReboot = $true }
+            if ($MsiRequiresReboot -eq "false") { $MsiRequiresReboot = $false }
+            elseif ($MsiRequiresReboot -eq "true") { $MsiRequiresReboot = $true }
 
             $mobileAppBody = GetWin32AppBody `
                 -MSI `
@@ -964,13 +949,13 @@ param
         else {
 
             $mobileAppBody = GetWin32AppBody -EXE -displayName "$DisplayName" -publisher "$publisher" `
-            -description $description -filename $FileName -SetupFileName "$SetupFileName" `
-            -installExperience $installExperience -installCommandLine $installCmdLine `
-            -uninstallCommandLine $uninstallcmdline
+                -description $description -filename $FileName -SetupFileName "$SetupFileName" `
+                -installExperience $installExperience -installCommandLine $installCmdLine `
+                -uninstallCommandLine $uninstallcmdline
 
         }
 
-        if($DetectionRules.'@odata.type' -contains "#microsoft.graph.win32LobAppPowerShellScriptDetection" -and @($DetectionRules).'@odata.type'.Count -gt 1){
+        if ($DetectionRules.'@odata.type' -contains "#microsoft.graph.win32LobAppPowerShellScriptDetection" -and @($DetectionRules).'@odata.type'.Count -gt 1) {
 
             Write-Host
             Write-Warning "A Detection Rule can either be 'Manually configure detection rules' or 'Use a custom detection script'"
@@ -982,15 +967,15 @@ param
 
         else {
 
-        $mobileAppBody | Add-Member -MemberType NoteProperty -Name 'detectionRules' -Value $detectionRules
+            $mobileAppBody | Add-Member -MemberType NoteProperty -Name 'detectionRules' -Value $detectionRules
 
         }
 
         #ReturnCodes
 
-        if($returnCodes){
+        if ($returnCodes) {
         
-        $mobileAppBody | Add-Member -MemberType NoteProperty -Name 'returnCodes' -Value @($returnCodes)
+            $mobileAppBody | Add-Member -MemberType NoteProperty -Name 'returnCodes' -Value @($returnCodes)
 
         }
 
@@ -1006,20 +991,20 @@ param
 
         Write-Host
         Write-Host "Creating application in Intune..." -ForegroundColor Yellow
-		$mobileApp = MakePostRequest "mobileApps" ($mobileAppBody | ConvertTo-Json);
+        $mobileApp = MakePostRequest "mobileApps" ($mobileAppBody | ConvertTo-Json);
 
-		# Get the content version for the new app (this will always be 1 until the new app is committed).
+        # Get the content version for the new app (this will always be 1 until the new app is committed).
         Write-Host
         Write-Host "Creating Content Version in the service for the application..." -ForegroundColor Yellow
-		$appId = $mobileApp.id;
-		$contentVersionUri = "mobileApps/$appId/$LOBType/contentVersions";
-		$contentVersion = MakePostRequest $contentVersionUri "{}";
+        $appId = $mobileApp.id;
+        $contentVersionUri = "mobileApps/$appId/$LOBType/contentVersions";
+        $contentVersion = MakePostRequest $contentVersionUri "{}";
 
         # Encrypt file and Get File Information
         Write-Host
         Write-Host "Getting Encryption Information for '$SourceFile'..." -ForegroundColor Yellow
 
-        $encryptionInfo = @{};
+        $encryptionInfo = @{ };
         $encryptionInfo.encryptionKey = $DetectionXML.ApplicationInfo.EncryptionInfo.EncryptionKey
         $encryptionInfo.macKey = $DetectionXML.ApplicationInfo.EncryptionInfo.macKey
         $encryptionInfo.initializationVector = $DetectionXML.ApplicationInfo.EncryptionInfo.initializationVector
@@ -1028,7 +1013,7 @@ param
         $encryptionInfo.fileDigest = $DetectionXML.ApplicationInfo.EncryptionInfo.fileDigest
         $encryptionInfo.fileDigestAlgorithm = $DetectionXML.ApplicationInfo.EncryptionInfo.fileDigestAlgorithm
 
-        $fileEncryptionInfo = @{};
+        $fileEncryptionInfo = @{ };
         $fileEncryptionInfo.fileEncryptionInfo = $encryptionInfo;
 
         # Extracting encrypted file
@@ -1037,49 +1022,49 @@ param
         [int64]$Size = $DetectionXML.ApplicationInfo.UnencryptedContentSize
         $EncrySize = (Get-Item "$IntuneWinFile").Length
 
-		# Create a new file for the app.
+        # Create a new file for the app.
         Write-Host
         Write-Host "Creating a new file entry in Azure for the upload..." -ForegroundColor Yellow
-		$contentVersionId = $contentVersion.id;
-		$fileBody = GetAppFileBody "$FileName" $Size $EncrySize $null;
-		$filesUri = "mobileApps/$appId/$LOBType/contentVersions/$contentVersionId/files";
-		$file = MakePostRequest $filesUri ($fileBody | ConvertTo-Json);
+        $contentVersionId = $contentVersion.id;
+        $fileBody = GetAppFileBody "$FileName" $Size $EncrySize $null;
+        $filesUri = "mobileApps/$appId/$LOBType/contentVersions/$contentVersionId/files";
+        $file = MakePostRequest $filesUri ($fileBody | ConvertTo-Json);
 	
-		# Wait for the service to process the new file request.
+        # Wait for the service to process the new file request.
         Write-Host
         Write-Host "Waiting for the file entry URI to be created..." -ForegroundColor Yellow
-		$fileId = $file.id;
-		$fileUri = "mobileApps/$appId/$LOBType/contentVersions/$contentVersionId/files/$fileId";
-		$file = WaitForFileProcessing $fileUri "AzureStorageUriRequest";
+        $fileId = $file.id;
+        $fileUri = "mobileApps/$appId/$LOBType/contentVersions/$contentVersionId/files/$fileId";
+        $file = WaitForFileProcessing $fileUri "AzureStorageUriRequest";
 
-		# Upload the content to Azure Storage.
+        # Upload the content to Azure Storage.
         Write-Host
         Write-Host "Uploading file to Azure Storage..." -f Yellow
 
-		$sasUri = $file.azureStorageUri;
-		UploadFileToAzureStorage $file.azureStorageUri "$IntuneWinFile" $fileUri;
+        $sasUri = $file.azureStorageUri;
+        UploadFileToAzureStorage $file.azureStorageUri "$IntuneWinFile" $fileUri;
 
         # Need to Add removal of IntuneWin file
         $IntuneWinFolder = [System.IO.Path]::GetDirectoryName("$IntuneWinFile")
         Remove-Item "$IntuneWinFile" -Force
 
-		# Commit the file.
+        # Commit the file.
         Write-Host
         Write-Host "Committing the file into Azure Storage..." -ForegroundColor Yellow
-		$commitFileUri = "mobileApps/$appId/$LOBType/contentVersions/$contentVersionId/files/$fileId/commit";
-		MakePostRequest $commitFileUri ($fileEncryptionInfo | ConvertTo-Json);
+        $commitFileUri = "mobileApps/$appId/$LOBType/contentVersions/$contentVersionId/files/$fileId/commit";
+        MakePostRequest $commitFileUri ($fileEncryptionInfo | ConvertTo-Json);
 
-		# Wait for the service to process the commit file request.
+        # Wait for the service to process the commit file request.
         Write-Host
         Write-Host "Waiting for the service to process the commit file request..." -ForegroundColor Yellow
-		$file = WaitForFileProcessing $fileUri "CommitFile";
+        $file = WaitForFileProcessing $fileUri "CommitFile";
 
-		# Commit the app.
+        # Commit the app.
         Write-Host
         Write-Host "Committing the file into Azure Storage..." -ForegroundColor Yellow
-		$commitAppUri = "mobileApps/$appId";
-		$commitAppBody = GetAppCommitBody $contentVersionId $LOBType;
-		MakePatchRequest $commitAppUri ($commitAppBody | ConvertTo-Json);
+        $commitAppUri = "mobileApps/$appId";
+        $commitAppBody = GetAppCommitBody $contentVersionId $LOBType;
+        MakePatchRequest $commitAppUri ($commitAppBody | ConvertTo-Json);
 
         Write-Host "Sleeping for $sleep seconds to allow patch completion..." -f Magenta
         Start-Sleep $sleep
@@ -1089,18 +1074,18 @@ param
 	
     catch {
 
-		Write-Host "";
-		Write-Host -ForegroundColor Red "Aborting with exception: $($_.Exception.ToString())";
+        Write-Host "";
+        Write-Host -ForegroundColor Red "Aborting with exception: $($_.Exception.ToString())";
 	
     }
 }
 
 ####################################################
 
-Function Test-AuthToken(){
+Function Test-AuthToken() {
 
     # Checking if authToken exists before running authentication
-    if($global:authToken){
+    if ($global:authToken) {
 
         # Setting DateTime to Universal time to work in all timezones
         $DateTime = (Get-Date).ToUniversalTime()
@@ -1108,38 +1093,38 @@ Function Test-AuthToken(){
         # If the authToken exists checking when it expires
         $TokenExpires = ($authToken.ExpiresOn.datetime - $DateTime).Minutes
 
-            if($TokenExpires -le 0){
+        if ($TokenExpires -le 0) {
 
             write-host "Authentication Token expired" $TokenExpires "minutes ago" -ForegroundColor Yellow
             write-host
 
-                # Defining Azure AD tenant name, this is the name of your Azure Active Directory (do not use the verified domain name)
+            # Defining Azure AD tenant name, this is the name of your Azure Active Directory (do not use the verified domain name)
 
-                if($User -eq $null -or $User -eq ""){
+            if ($User -eq $null -or $User -eq "") {
 
                 $Global:User = Read-Host -Prompt "Please specify your user principal name for Azure Authentication"
                 Write-Host
 
-                }
+            }
 
             $global:authToken = Get-AuthToken -User $User
 
-            }
+        }
     }
 
     # Authentication doesn't exist, calling Get-AuthToken function
 
     else {
 
-        if($User -eq $null -or $User -eq ""){
+        if ($User -eq $null -or $User -eq "") {
 
             $Global:User = Read-Host -Prompt "Please specify your user principal name for Azure Authentication"
             Write-Host
 
         }
 
-    # Getting the authorization token
-    $global:authToken = Get-AuthToken -User $User
+        # Getting the authorization token
+        $global:authToken = Get-AuthToken -User $User
 
     }
 }
@@ -1171,15 +1156,15 @@ $DetectionXML = Get-IntuneWinXML "$SourceFile" -fileName "detection.xml"
 
 # Defining Intunewin32 detectionRules
 $FileRule = New-DetectionRule -File -Path "C:\Program Files\Application" `
--FileOrFolderName "application.exe" -FileDetectionType exists -check32BitOn64System False
+    -FileOrFolderName "application.exe" -FileDetectionType exists -check32BitOn64System False
 
 $RegistryRule = New-DetectionRule -Registry -RegistryKeyPath "HKEY_LOCAL_MACHINE\SOFTWARE\Program" `
--RegistryDetectionType exists -check32BitRegOn64System True
+    -RegistryDetectionType exists -check32BitRegOn64System True
 
 $MSIRule = New-DetectionRule -MSI -MSIproductCode $DetectionXML.ApplicationInfo.MsiInfo.MsiProductCode
 
 # Creating Array for detection Rule
-$DetectionRule = @($FileRule,$RegistryRule,$MSIRule)
+$DetectionRule = @($FileRule, $RegistryRule, $MSIRule)
 
 $ReturnCodes = Get-DefaultReturnCodes
 
@@ -1188,8 +1173,8 @@ $ReturnCodes += New-ReturnCode -returnCode 145 -type hardReboot
 
 # Win32 Application Upload
 Upload-Win32Lob -SourceFile "$SourceFile" -publisher "Publisher" `
--description "Description" -detectionRules $DetectionRule -returnCodes $ReturnCodes `
--installCmdLine "powershell.exe .\install.ps1" `
--uninstallCmdLine "powershell.exe .\uninstall.ps1"
+    -description "Description" -detectionRules $DetectionRule -returnCodes $ReturnCodes `
+    -installCmdLine "powershell.exe .\install.ps1" `
+    -uninstallCmdLine "powershell.exe .\uninstall.ps1"
 
 ####################################################


### PR DESCRIPTION
You can now choose exe / msi / powershell to cover more examples of how applications can be installed.

pretty simple change to the function - I've also done a little code cleanup - fixed some formatting (just formatted in VSCode) and removed a chunk of random semi-colons from the code that do nothing.

Should all work exactly the same!!