### PR TITLE
Adding support to export a managed app protection policy for Windows 10

### DIFF
--- a/AppProtectionPolicy/ManagedAppPolicy_Export.ps1
+++ b/AppProtectionPolicy/ManagedAppPolicy_Export.ps1
@@ -513,7 +513,19 @@ if($ManagedAppPolicies){
             Export-JSONData -JSON $AppProtectionPolicy -ExportPath "$ExportPath"
 
         }
+		
+        elseif($ManagedAppPolicy.'@odata.type' -eq "#microsoft.graph.windowsInformationProtectionPolicy"){
 
+            $AppProtectionPolicy = Get-ManagedAppProtection -id $ManagedAppPolicy.id -OS "WIP_WE"
+
+            $AppProtectionPolicy | Add-Member -MemberType NoteProperty -Name '@odata.type' -Value "#microsoft.graph.windowsInformationProtectionPolicy"
+
+            $AppProtectionPolicy
+
+            Export-JSONData -JSON $AppProtectionPolicy -ExportPath "$ExportPath"
+
+        }
+		
     Write-Host
 
     }


### PR DESCRIPTION
Adding support to export a managed app protection policy for Windows 10 without enrollment configured in Intune.

This uses the already existing cmdlet `Get-ManagedAppProtection` to get `WIP_WE` policies. 