### PR TITLE
Update ManagedDevices_Get.ps1

### DIFF
--- a/ManagedDevices/ManagedDevices_Get.ps1
+++ b/ManagedDevices/ManagedDevices_Get.ps1
@@ -236,59 +236,6 @@ try {
 
 ####################################################
 
-Function Get-ManagedDeviceUser(){
-
-<#
-.SYNOPSIS
-This function is used to get a Managed Device username from the Graph API REST interface
-.DESCRIPTION
-The function connects to the Graph API Interface and gets a managed device users registered with Intune MDM
-.EXAMPLE
-Get-ManagedDeviceUser -DeviceID $DeviceID
-Returns a managed device user registered in Intune
-.NOTES
-NAME: Get-ManagedDeviceUser
-#>
-
-[cmdletbinding()]
-
-param
-(
-    [Parameter(Mandatory=$true,HelpMessage="DeviceID (guid) for the device on must be specified:")]
-    $DeviceID
-)
-
-# Defining Variables
-$graphApiVersion = "beta"
-$Resource = "deviceManagement/manageddevices('$DeviceID')?`$select=userId"
-
-    try {
-
-    $uri = "https://graph.microsoft.com/$graphApiVersion/$($Resource)"
-    Write-Verbose $uri
-    (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).userId
-
-    }
-
-    catch {
-
-    $ex = $_.Exception
-    $errorResponse = $ex.Response.GetResponseStream()
-    $reader = New-Object System.IO.StreamReader($errorResponse)
-    $reader.BaseStream.Position = 0
-    $reader.DiscardBufferedData()
-    $responseBody = $reader.ReadToEnd();
-    Write-Host "Response content:`n$responseBody" -f Red
-    Write-Error "Request to $Uri failed with HTTP Status $($ex.Response.StatusCode) $($ex.Response.StatusDescription)"
-    write-host
-    break
-
-    }
-
-}
-
-####################################################
-
 Function Get-AADUser(){
 
 <#
@@ -434,7 +381,7 @@ if($ManagedDevices){
 
         if($Device.deviceRegistrationState -eq "registered"){
 
-        $UserId = Get-ManagedDeviceUser -DeviceID $DeviceID
+        $UserId = $Device.userId
 
         $User = Get-AADUser $userId
 


### PR DESCRIPTION
Not sure if you want to keep the Get-ManagedDeviceUser method, to show more code regarding intune. 

But the userId returned from Get-ManagedDeviceUser() is the same as userId received from $Device object when looping through each  $Device from Get-ManagedDevices(). 
Could remove Get-ManageDeviceUser() method, and use $UserId = $Device.userId on line 384