### PR TITLE
wrong parameter for Get-AADGroup -groupId instead of -id

### DIFF
--- a/Applications/Application_MDM_Get.ps1
+++ b/Applications/Application_MDM_Get.ps1
@@ -434,7 +434,7 @@ $App_Assignment = Get-ApplicationAssignment -ApplicationId $_.id
 
         foreach($Assignment in $App_Assignment){
 
-        write-host "AAD Group:"(Get-AADGroup -id $Assignment.target.GroupId).displayName "- Install Intent:"$Assignment.intent
+        write-host "AAD Group:"(Get-AADGroup -groupId $Assignment.target.GroupId).displayName "- Install Intent:"$Assignment.intent
 
         }
 


### PR DESCRIPTION
Line 437 - Correction of -id parameter to -groupId