### PR TITLE
Remove en-dashes and replace with correct  hyphens

### DIFF
--- a/AndroidEnterprise/Get-AndroidDedicatedDeviceProfiles.ps1
+++ b/AndroidEnterprise/Get-AndroidDedicatedDeviceProfiles.ps1
@@ -168,7 +168,7 @@ $Resource = "deviceManagement/androidDeviceOwnerEnrollmentProfiles"
         
         $now = (Get-Date -Format s)    
         $uri = "https://graph.microsoft.com/$graphApiVersion/$($Resource)?`$filter=tokenExpirationDateTime gt $($now)z"
-        (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).value
+        (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).value
             
     }
     

--- a/AndroidEnterprise/Get-AndroidDedicatedDeviceQRCode.ps1
+++ b/AndroidEnterprise/Get-AndroidDedicatedDeviceQRCode.ps1
@@ -169,7 +169,7 @@ $Resource = "deviceManagement/androidDeviceOwnerEnrollmentProfiles"
         
         $now = (Get-Date -Format s)    
         $uri = "https://graph.microsoft.com/$graphApiVersion/$($Resource)?`$filter=tokenExpirationDateTime gt $($now)z"
-        (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).value
+        (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).value
     
     }
     
@@ -218,7 +218,7 @@ $graphApiVersion = "Beta"
             
         $Resource = "deviceManagement/androidDeviceOwnerEnrollmentProfiles/$($Profileid)?`$select=qrCodeImage"
         $uri = "https://graph.microsoft.com/$graphApiVersion/$Resource"
-        (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get)
+        (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get)
                     
     }
     

--- a/AndroidEnterprise/Get-AndroidWorkProfileConfiguration.ps1
+++ b/AndroidEnterprise/Get-AndroidWorkProfileConfiguration.ps1
@@ -225,14 +225,14 @@ $Group_resource = "groups"
         if($id){
 
         $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)?`$filter=id eq '$id'"
-        (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+        (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
 
         }
         
         elseif($GroupName -eq "" -or $GroupName -eq $null){
         
         $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)"
-        (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+        (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
         
         }
 
@@ -241,21 +241,21 @@ $Group_resource = "groups"
             if(!$Members){
 
             $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)?`$filter=displayname eq '$GroupName'"
-            (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+            (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
             
             }
             
             elseif($Members){
             
             $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)?`$filter=displayname eq '$GroupName'"
-            $Group = (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+            $Group = (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
             
                 if($Group){
 
                 $GID = $Group.id
 
                 $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)/$GID/Members"
-                (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+                (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
 
                 }
 

--- a/AppProtectionPolicy/ManagedAppPolicy_WIP_Add_Assign.ps1
+++ b/AppProtectionPolicy/ManagedAppPolicy_WIP_Add_Assign.ps1
@@ -507,14 +507,14 @@ $Group_resource = "groups"
         if($id){
 
         $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)?`$filter=id eq '$id'"
-        (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+        (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
 
         }
         
         elseif($GroupName -eq "" -or $GroupName -eq $null){
         
         $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)"
-        (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+        (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
         
         }
 
@@ -523,14 +523,14 @@ $Group_resource = "groups"
             if(!$Members){
 
             $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)?`$filter=displayname eq '$GroupName'"
-            (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+            (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
             
             }
             
             elseif($Members){
             
             $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)?`$filter=displayname eq '$GroupName'"
-            $Group = (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+            $Group = (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
             
                 if($Group){
 
@@ -540,7 +540,7 @@ $Group_resource = "groups"
                 write-host
 
                 $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)/$GID/Members"
-                (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+                (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
 
                 }
 

--- a/AppleEnrollment/AppleDEPProfile_Assign.ps1
+++ b/AppleEnrollment/AppleDEPProfile_Assign.ps1
@@ -222,7 +222,7 @@ Param(
                 
                 $Resource = "deviceManagement/depOnboardingSettings/$tokenid/"
                 $uri = "https://graph.microsoft.com/$graphApiVersion/$($Resource)"
-                (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get)
+                (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get)
                      
                 }
     
@@ -230,7 +230,7 @@ Param(
                 
                 $Resource = "deviceManagement/depOnboardingSettings/"
                 $uri = "https://graph.microsoft.com/$graphApiVersion/$($Resource)"
-                (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).value
+                (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).value
                 
                 }
                    
@@ -501,7 +501,7 @@ $graphApiVersion = "beta"
 $Resource = "deviceManagement/depOnboardingSettings/$($id)/importedAppleDeviceIdentities?`$filter=discoverySource eq 'deviceEnrollmentProgram' and contains(serialNumber,'$DeviceSerialNumber')"
 
 $uri = "https://graph.microsoft.com/$graphApiVersion/$($Resource)"
-$SearchResult = (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).value
+$SearchResult = (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).value
 
 if (!($SearchResult)){
 

--- a/AppleEnrollment/AppleDEP_Sync.ps1
+++ b/AppleEnrollment/AppleDEP_Sync.ps1
@@ -227,7 +227,7 @@ $graphApiVersion = "beta"
         
         $Resource = "deviceManagement/depOnboardingSettings/$tokenid/"
         $uri = "https://graph.microsoft.com/$graphApiVersion/$($Resource)"
-        (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get)
+        (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get)
                 
         }
 
@@ -235,7 +235,7 @@ $graphApiVersion = "beta"
         
         $Resource = "deviceManagement/depOnboardingSettings/"
         $uri = "https://graph.microsoft.com/$graphApiVersion/$($Resource)"
-        (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).value
+        (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).value
         
         }
                

--- a/ApplicationSync/AppleVPP_Sync.ps1
+++ b/ApplicationSync/AppleVPP_Sync.ps1
@@ -228,7 +228,7 @@ $Resource = "deviceAppManagement/vppTokens"
     try {
                 
         $uri = "https://graph.microsoft.com/$graphApiVersion/$($Resource)"
-        (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).value
+        (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).value
             
     }
     

--- a/Applications/Application_Get_Assign.ps1
+++ b/Applications/Application_Get_Assign.ps1
@@ -171,7 +171,7 @@ $Resource = "deviceAppManagement/mobileApps"
     try {
         
     $uri = "https://graph.microsoft.com/$graphApiVersion/$($Resource)"
-    (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value | ? { (!($_.'@odata.type').Contains("managed")) }
+    (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value | ? { (!($_.'@odata.type').Contains("managed")) }
 
     }
     
@@ -231,7 +231,7 @@ $Resource = "deviceAppManagement/mobileApps/$ApplicationId/?`$expand=categories,
         else {
         
         $uri = "https://graph.microsoft.com/$graphApiVersion/$($Resource)"
-        (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get)
+        (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get)
         
         }
     
@@ -470,14 +470,14 @@ $Group_resource = "groups"
         if($id){
 
         $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)?`$filter=id eq '$id'"
-        (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+        (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
 
         }
         
         elseif($GroupName -eq "" -or $GroupName -eq $null){
         
         $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)"
-        (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+        (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
         
         }
 
@@ -486,14 +486,14 @@ $Group_resource = "groups"
             if(!$Members){
 
             $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)?`$filter=displayname eq '$GroupName'"
-            (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+            (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
             
             }
             
             elseif($Members){
             
             $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)?`$filter=displayname eq '$GroupName'"
-            $Group = (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+            $Group = (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
             
                 if($Group){
 
@@ -503,7 +503,7 @@ $Group_resource = "groups"
                 write-host
 
                 $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)/$GID/Members"
-                (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+                (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
 
                 }
 

--- a/Applications/Application_MacOSOffice365_Add_Assign.ps1
+++ b/Applications/Application_MacOSOffice365_Add_Assign.ps1
@@ -376,14 +376,14 @@ $Group_resource = "groups"
         if($id){
 
         $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)?`$filter=id eq '$id'"
-        (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+        (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
 
         }
         
         elseif($GroupName -eq "" -or $GroupName -eq $null){
         
         $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)"
-        (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+        (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
         
         }
 
@@ -392,14 +392,14 @@ $Group_resource = "groups"
             if(!$Members){
 
             $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)?`$filter=displayname eq '$GroupName'"
-            (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+            (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
             
             }
             
             elseif($Members){
             
             $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)?`$filter=displayname eq '$GroupName'"
-            $Group = (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+            $Group = (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
             
                 if($Group){
 
@@ -409,7 +409,7 @@ $Group_resource = "groups"
                 write-host
 
                 $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)/$GID/Members"
-                (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+                (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
 
                 }
 

--- a/Applications/Application_Office365_Add_Assign.ps1
+++ b/Applications/Application_Office365_Add_Assign.ps1
@@ -376,14 +376,14 @@ $Group_resource = "groups"
         if($id){
 
         $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)?`$filter=id eq '$id'"
-        (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+        (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
 
         }
         
         elseif($GroupName -eq "" -or $GroupName -eq $null){
         
         $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)"
-        (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+        (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
         
         }
 
@@ -392,14 +392,14 @@ $Group_resource = "groups"
             if(!$Members){
 
             $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)?`$filter=displayname eq '$GroupName'"
-            (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+            (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
             
             }
             
             elseif($Members){
             
             $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)?`$filter=displayname eq '$GroupName'"
-            $Group = (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+            $Group = (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
             
                 if($Group){
 
@@ -409,7 +409,7 @@ $Group_resource = "groups"
                 write-host
 
                 $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)/$GID/Members"
-                (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+                (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
 
                 }
 

--- a/Auditing/Auditing_User_Report_Get.ps1
+++ b/Auditing/Auditing_User_Report_Get.ps1
@@ -183,7 +183,7 @@ $User_resource = "users"
         if($userPrincipalName -eq "" -or $userPrincipalName -eq $null){
         
         $uri = "https://graph.microsoft.com/$graphApiVersion/$($User_resource)"
-        (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+        (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
         
         }
 
@@ -193,7 +193,7 @@ $User_resource = "users"
 
             $uri = "https://graph.microsoft.com/$graphApiVersion/$($User_resource)/$userPrincipalName"
             Write-Verbose $uri
-            Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get
+            Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get
 
             }
 
@@ -201,7 +201,7 @@ $User_resource = "users"
 
             $uri = "https://graph.microsoft.com/$graphApiVersion/$($User_resource)/$userPrincipalName/$Property"
             Write-Verbose $uri
-            (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+            (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
 
             }
 

--- a/RBAC/RBAC_ScopeTags_ApplicationAssign.ps1
+++ b/RBAC/RBAC_ScopeTags_ApplicationAssign.ps1
@@ -242,21 +242,21 @@ $Resource = "deviceAppManagement/mobileApps"
         if($displayName){
 
             $uri = "https://graph.microsoft.com/$graphApiVersion/$($Resource)?`$filter=displayName eq '$displayName'"
-            (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).value
+            (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).value
 
         }
         
         elseif($id){
 
             $uri = "https://graph.microsoft.com/$graphApiVersion/$($Resource)/$id"
-            (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get)
+            (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get)
 
         }
 
         else {
 
             $uri = "https://graph.microsoft.com/$graphApiVersion/$($Resource)"
-            (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value | ? { (!($_.'@odata.type').Contains("managed")) }
+            (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value | ? { (!($_.'@odata.type').Contains("managed")) }
         
         }
     }
@@ -331,7 +331,7 @@ $JSON = @"
 
         else {
 
-            $object = New-Object –TypeName PSObject
+            $object = New-Object -TypeName PSObject
             $object | Add-Member -MemberType NoteProperty -Name '@odata.type' -Value "$Type"
             $object | Add-Member -MemberType NoteProperty -Name 'roleScopeTagIds' -Value @($ScopeTags)
             $JSON = $object | ConvertTo-Json

--- a/RBAC/RBAC_ScopeTags_ApplicationUnAssign.ps1
+++ b/RBAC/RBAC_ScopeTags_ApplicationUnAssign.ps1
@@ -242,21 +242,21 @@ $Resource = "deviceAppManagement/mobileApps"
         if($displayName){
 
             $uri = "https://graph.microsoft.com/$graphApiVersion/$($Resource)?`$filter=displayName eq '$displayName'"
-            (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).value
+            (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).value
 
         }
         
         elseif($id){
 
             $uri = "https://graph.microsoft.com/$graphApiVersion/$($Resource)/$id"
-            (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get)
+            (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get)
 
         }
 
         else {
 
             $uri = "https://graph.microsoft.com/$graphApiVersion/$($Resource)"
-            (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value | ? { (!($_.'@odata.type').Contains("managed")) }
+            (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value | ? { (!($_.'@odata.type').Contains("managed")) }
         
         }
     }
@@ -331,7 +331,7 @@ $JSON = @"
 
         else {
 
-            $object = New-Object –TypeName PSObject
+            $object = New-Object -TypeName PSObject
             $object | Add-Member -MemberType NoteProperty -Name '@odata.type' -Value "$Type"
             $object | Add-Member -MemberType NoteProperty -Name 'roleScopeTagIds' -Value @($ScopeTags)
             $JSON = $object | ConvertTo-Json

--- a/RBAC/RBAC_ScopeTags_DeviceAssign.ps1
+++ b/RBAC/RBAC_ScopeTags_DeviceAssign.ps1
@@ -358,7 +358,7 @@ $JSON = @"
 
         else {
 
-            $object = New-Object –TypeName PSObject
+            $object = New-Object -TypeName PSObject
             $object | Add-Member -MemberType NoteProperty -Name 'roleScopeTagIds' -Value @($ScopeTags)
             $JSON = $object | ConvertTo-Json
 

--- a/RBAC/RBAC_ScopeTags_DeviceUnAssign.ps1
+++ b/RBAC/RBAC_ScopeTags_DeviceUnAssign.ps1
@@ -294,7 +294,7 @@ $JSON = @"
 
         else {
 
-        $object = New-Object –TypeName PSObject
+        $object = New-Object -TypeName PSObject
         $object | Add-Member -MemberType NoteProperty -Name 'roleScopeTagIds' -Value @($ScopeTags)
 
         $JSON = $object | ConvertTo-Json

--- a/RBAC/RBAC_ScopeTags_PolicyAssign.ps1
+++ b/RBAC/RBAC_ScopeTags_PolicyAssign.ps1
@@ -375,7 +375,7 @@ $JSON = @"
 
         else {
 
-            $object = New-Object –TypeName PSObject
+            $object = New-Object -TypeName PSObject
             $object | Add-Member -MemberType NoteProperty -Name '@odata.type' -Value "$Type"
             $object | Add-Member -MemberType NoteProperty -Name 'roleScopeTagIds' -Value @($ScopeTags)
             $JSON = $object | ConvertTo-Json
@@ -454,7 +454,7 @@ $JSON = @"
 
         else {
 
-            $object = New-Object –TypeName PSObject
+            $object = New-Object -TypeName PSObject
             $object | Add-Member -MemberType NoteProperty -Name '@odata.type' -Value "$Type"
             $object | Add-Member -MemberType NoteProperty -Name 'roleScopeTagIds' -Value @($ScopeTags)
             $JSON = $object | ConvertTo-Json

--- a/RBAC/RBAC_ScopeTags_PolicyUnAssign.ps1
+++ b/RBAC/RBAC_ScopeTags_PolicyUnAssign.ps1
@@ -374,7 +374,7 @@ $JSON = @"
 
         else {
 
-            $object = New-Object –TypeName PSObject
+            $object = New-Object -TypeName PSObject
             $object | Add-Member -MemberType NoteProperty -Name '@odata.type' -Value "$Type"
             $object | Add-Member -MemberType NoteProperty -Name 'roleScopeTagIds' -Value @($ScopeTags)
             $JSON = $object | ConvertTo-Json
@@ -453,7 +453,7 @@ $JSON = @"
 
         else {
 
-            $object = New-Object –TypeName PSObject
+            $object = New-Object -TypeName PSObject
             $object | Add-Member -MemberType NoteProperty -Name '@odata.type' -Value "$Type"
             $object | Add-Member -MemberType NoteProperty -Name 'roleScopeTagIds' -Value @($ScopeTags)
             $JSON = $object | ConvertTo-Json

--- a/RemoteActionAudit/RemoteActionAudit_Get.ps1
+++ b/RemoteActionAudit/RemoteActionAudit_Get.ps1
@@ -171,7 +171,7 @@ $Resource = "deviceManagement/remoteActionAudits"
     try {
 
     $uri = "https://graph.microsoft.com/$graphApiVersion/$($Resource)"
-    (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+    (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
 
     }
 

--- a/SoftwareUpdates/Windows10_SoftwareUpdates_Add_Assign.ps1
+++ b/SoftwareUpdates/Windows10_SoftwareUpdates_Add_Assign.ps1
@@ -366,14 +366,14 @@ $Group_resource = "groups"
         if($id){
 
         $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)?`$filter=id eq '$id'"
-        (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+        (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
 
         }
         
         elseif($GroupName -eq "" -or $GroupName -eq $null){
         
         $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)"
-        (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+        (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
         
         }
 
@@ -382,14 +382,14 @@ $Group_resource = "groups"
             if(!$Members){
 
             $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)?`$filter=displayname eq '$GroupName'"
-            (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+            (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
             
             }
             
             elseif($Members){
             
             $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)?`$filter=displayname eq '$GroupName'"
-            $Group = (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+            $Group = (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
             
                 if($Group){
 
@@ -399,7 +399,7 @@ $Group_resource = "groups"
                 write-host
 
                 $uri = "https://graph.microsoft.com/$graphApiVersion/$($Group_resource)/$GID/Members"
-                (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).Value
+                (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).Value
 
                 }
 

--- a/iOSAppProvisioningProfiles/iOSAppProvisioningProfile_Analysis.ps1
+++ b/iOSAppProvisioningProfiles/iOSAppProvisioningProfile_Analysis.ps1
@@ -264,7 +264,7 @@ $Resource = "deviceAppManagement/iosLobAppProvisioningConfigurations?`$expand=as
     try {
                 
         $uri = "https://graph.microsoft.com/$graphApiVersion/$($Resource)"
-        (Invoke-RestMethod -Uri $uri –Headers $authToken –Method Get).value
+        (Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).value
 
             
         }


### PR DESCRIPTION
In a lot of the `Invoke-RestMethod` calls, the hyphen (`-`) characters are actually en-dash (`–`) characters.  If a function from these samples is copied into a PowerShell window, it usually converts to plain text and replaces the en-dash characters with hyphens.  However, if the code is downloaded or copied into a program that accepts the en-dash characters, then the code is saved and imported into PowerShell (e.g. through a module file), the `Invoke-RestMethod` command will fail with an error:

```Powershell
Invoke-RestMethod : A positional parameter cannot be found that accepts argument 'â€Headers System.Collections.Hashtable â€Method'.
```

This pull request removes all en-dash characters currently present in .ps1 files and replaces them with correct hyphens.