### PR TITLE
Update Validate-NDESConfiguration.ps1

### DIFF
--- a/CertificationAuthority/Validate-NDESConfiguration.ps1
+++ b/CertificationAuthority/Validate-NDESConfiguration.ps1
@@ -63,7 +63,7 @@ Param(
 [parameter(Mandatory=$true,ParameterSetName="NormalRun")]
 [alias("ca")]
 [ValidateScript({
-    $Domain = (Get-WmiObject Win32_ComputerSystem).domain
+    $Domain = (Get-ADDomain).DNSRoot
         if ($_ -match $Domain) {
 
         $True


### PR DESCRIPTION
Get-WmiObject is depracated 
(https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/get-wmiobject?view=powershell-5.1)

This caused an issue when running with PowerShell 7 as a I received: The term 'Get-WmiObject' is not recognized as a name of a cmdlet, function, script file, or executable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again. 

Replaced:
(Get-WmiObject Win32_ComputerSystem).domain

With:
(Get-ADDomain).DNSRoot